### PR TITLE
Avoid find and basename in the hot bit of the p macro

### DIFF
--- a/modules/p/p.sh
+++ b/modules/p/p.sh
@@ -19,7 +19,7 @@ function p() {
         p_cd $PROJECTS_DIR
     else
         # Find all folders in PROJECTS_DIR
-        local projects="`find $PROJECTS_DIR -mindepth 1 -maxdepth 1 -type d -exec basename {} \;`"
+        local projects="$(ls -p ${PROJECTS_DIR} | grep /$ | sed -e 's/\/$//;')"
 
         # For each argument, grep for folders that match that argument in the remaining folders
         for arg in $@


### PR DESCRIPTION
This shaves several seconds off the time it takes to `p projectname` on my mac

On my Linux box it makes it take about 0.14s instead of 0,58s.

I do admit to having several hundred directories in my `$PROJECTS_DIR` on both machines :)